### PR TITLE
Security Fix and Update Version 1.1.2 to use get parameter instead of params for nested pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Kirby Secured Pages
 
-![Version](https://img.shields.io/badge/Version-1.1.1-blue.svg) ![License](https://img.shields.io/badge/License-MIT-green.svg) ![Kirby](https://img.shields.io/badge/Kirby-3.x-f0c674.svg)
+![Version](https://img.shields.io/badge/Version-1.1.2-blue.svg) ![License](https://img.shields.io/badge/License-MIT-green.svg) ![Kirby](https://img.shields.io/badge/Kirby-3.x-f0c674.svg)
 
 With this plugin for [Kirby CMS](http://getkirby.com) you can prevent unauthorized users to access a page or a hierarchy of pages. The permission will be granted by a user group. If the user is not yet logged in, a login page will be displayed.
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "kerli81/securedpages",
     "description": "Protect pages from unauthorized users",
     "type": "kirby-plugin",
-    "version" : "1.1.1",
+    "version" : "1.1.2",
     "license": "MIT",
     "authors": [
         {

--- a/src/loginform/LoginFormCtrl.php
+++ b/src/loginform/LoginFormCtrl.php
@@ -16,7 +16,7 @@ return function ($kirby) {
 
     if (param('action') == 'logout' && $kirby->user()) {
         $kirby->user()->logout();
-        go(url('/no-permission', ['params' => ['prevloc' => param('prevloc')]]));
+        go(url(get('prevloc')));
     }
 
     $loginstatus = [

--- a/src/loginform/LoginFormCtrl.php
+++ b/src/loginform/LoginFormCtrl.php
@@ -28,7 +28,7 @@ return function ($kirby) {
         $form->withoutGuards()->loginAction();
 
         if ($form->success()) {
-            go(get('prevloc'));
+            go(url(get('prevloc')));
         }
     }
 


### PR DESCRIPTION
Related to this https://github.com/kerli81/kirby-securedpages/issues/12 and this https://github.com/kerli81/kirby-securedpages/issues/10